### PR TITLE
Fix warning caused by non-incremental sysimages

### DIFF
--- a/test/notebook.jl
+++ b/test/notebook.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.17.2
+# v0.17.3
 
 using Markdown
 using InteractiveUtils


### PR DESCRIPTION
Switch implementaion of the `PlutoWorkspaces` module marker to
just use a statically defined module rather than `eval`ing into
the `Base.__toplevel__` module to mark as "top-level". Instead
use custom wrapper functions that modify the behaviour of "top-level"
module detection.